### PR TITLE
Adjust the positions of two NPCs and some scenery

### DIFF
--- a/extras/config/storylines/data-quest.yml
+++ b/extras/config/storylines/data-quest.yml
@@ -46,7 +46,7 @@ npcs:
     name:
       en: Flora Notte
       de: Flora Notte
-    spawn: { x: 3460, y: 1100 }
+    spawn: { x: 2967, y: 1187 }
     dialogue:
       - cond: 'quest.credit1.done & ^quest.credit2.done & ^quest.credit3.done'
         type: sequence
@@ -95,7 +95,7 @@ npcs:
       en: Maxi Plunk
       de: Maxi Plunk
     type: citizenWheelchair
-    spawn: { x: 3340, y: 1300 }
+    spawn: { x: 3011, y: 1366 }
     dialogue:
       - cond: 'quest.credit1.done & ^quest.credit2.done & ^quest.credit3.done'
         type: sequence
@@ -273,7 +273,7 @@ npcs:
       en: Mike Backmill
       de: Mike Backmill
     type: citizenDough
-    spawn: { x: 2491, y: 1365 }
+    spawn: { x: 2832, y: 1430 }
     cond: 'quest.credit1.done'
     dialogue:
       - type: sequence
@@ -288,7 +288,7 @@ npcs:
     name:
       en: "Emmy"
     type: dogTan
-    spawn: { x: 2568, y: 1365 }
+    spawn: { x: 2906, y: 1350 }
     cond: 'quest.credit1.done'
     dialogue:
       - text:
@@ -395,7 +395,7 @@ npcs:
       en: "Franciszek Snowpinski"
       de: "Franciszek Snowpinski"
     type: citizenChamp
-    spawn: { x: 2818, y: 1350 }
+    spawn: { x: 2568, y: 1365 }
     cond: 'quest.credit3.done'
     dialogue:
       - type: sequence

--- a/extras/config/storylines/data-quest.yml
+++ b/extras/config/storylines/data-quest.yml
@@ -46,7 +46,7 @@ npcs:
     name:
       en: Flora Notte
       de: Flora Notte
-    spawn: { x: 2967, y: 1187 }
+    spawn: { x: 3167, y: 1287 }
     dialogue:
       - cond: 'quest.credit1.done & ^quest.credit2.done & ^quest.credit3.done'
         type: sequence
@@ -85,7 +85,7 @@ npcs:
     name:
       en: Dusty Grant
       de: Dusty Grant
-    spawn: { x: 2158, y: 1255 }
+    spawn: { x: 2158, y: 1305 }
     dialogue:
       - text:
           en: "We sailed for a while with MaRDI's math and data pioneers! Check out the Data Date video interviews in the MaRDI newsletter!"
@@ -468,15 +468,15 @@ scenery:
   helpboothback:
     spawn: { x: 5560, y: 2821 }
   ringlight:
-    spawn: { x: 2094, y: 1305 }
+    spawn: { x: 2094, y: 1355 }
   camera:
-    spawn: { x: 2235, y: 1313 }
+    spawn: { x: 2235, y: 1363 }
   tree1:
     spawn: { x: 2880, y: 1829 }
   tree2:
     spawn: { x: 3085, y: 1913 }
   tree3:
-    spawn: { x: 3617, y: 1464 }
+    spawn: { x: 3817, y: 1464 }
   tree4:
     spawn: { x: 4959, y: 2187 }
   tree5:


### PR DESCRIPTION
Adjust the positions of two NPCs to make room for the question mark speech bubbles, move the third tree to make room for player number 2, move two more sceneries together with NPC of the video blogger that belong to him.